### PR TITLE
Properly merge top level and font configurations

### DIFF
--- a/Builder/tirobuild.py
+++ b/Builder/tirobuild.py
@@ -89,7 +89,20 @@ class Font:
     def __init__(self, name, conf, project):
         self.name = name
 
-        conf = {**project, **conf}
+        # Merge keys from the top level (project) configuration into the
+        # current font’s conf.
+        conf = {**conf}
+        for key in project:
+            if key == "fonts":
+                continue
+            if key not in conf:
+                conf[key] = project[key]
+            elif isinstance(project[key], dict):
+                # We want to merge dictionaries from the two configurations, so
+                # that, say, names can be set in the project and over-ridden by
+                # the font’s conf.
+                conf[key] = {**project[key], **conf[key]}
+
         self.source = conf.get("source")
         self.ren = conf.get("glyphnames")
         self.ttf = conf.get("ttf", {})


### PR DESCRIPTION
This makes the following work:

```yml
names:
  1: Foo
fonts:
  Foo-Roman:
    source: Foo-Roman.designspace
    names:
      25: FooRoman
fonts:
  Foo-Italic:
    source: Foo-Italic.designspace
    names:
      25: FooItalic
```

Previously the top level `names:` would be completely over-ridden by the font-specific ones, now they are merged.

See #13