### PR TITLE
vtp-gdef: Allow setting ligature components

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Scales all GPOS data in a VOLT project file.
 ### VTPtools : vtp-skew
 Adjusts rise-over-run coordinates for GPOS data in a VOLT project file to a defined slant angle.
 
+### VTPtools : vtp-gdef
+Sets the GDEF glyph classes in a VOLT project from an input text file.
+
 ### VFJtools : vfj-propagate-anchors
 Propagates anchors from base to composite glyphs in FontLab 7 .vfj sources.
 

--- a/VTPtools/README.md
+++ b/VTPtools/README.md
@@ -56,7 +56,7 @@ glyphname2
 glyphname3
 ```
 
-Where glyph class is one of “base”, “mark”, “ligature”, and “component”.
+Where glyph class is one of “base”, “mark”, “ligature”, and “component”. For ligatures, glyph name can optionally be followed by space then the number of components, e.g. `ffi 3`.
 
 Usage example:
 


### PR DESCRIPTION
The glyph name for ligatures can be followed by a space the components number.