### PR TITLE
Prune unused user name IDs from font subsets

### DIFF
--- a/Builder/tirobuild.py
+++ b/Builder/tirobuild.py
@@ -557,7 +557,6 @@ class Font:
                 logger.info(f"Creating {self.filename} subset")
                 new = deepcopy(otf)
                 options = Options()
-                options.name_IDs = ["*"]
                 options.name_legacy = True
                 options.name_languages = ["*"]
                 options.recommended_glyphs = True
@@ -579,6 +578,10 @@ class Font:
 
                 options.drop_tables.remove("DSIG")
                 options.no_subset_tables += ["DSIG", "meta"]
+
+                options.name_IDs = [
+                    n.nameID for n in otf["name"].names if n.nameID < 256
+                ]
 
                 subsetter = Subsetter(options=options)
                 subsetter.populate(subset["glyphlist"])

--- a/Builder/tirobuild.py
+++ b/Builder/tirobuild.py
@@ -569,8 +569,7 @@ class Font:
                 options.symbol_cmap = True
                 options.layout_closure = False
                 options.prune_unicode_ranges = True
-                if hasattr(options, "prune_codepage_ranges"):
-                    options.prune_codepage_ranges = True
+                options.prune_codepage_ranges = True
                 options.passthrough_tables = False
                 options.recalc_average_width = True
                 options.ignore_missing_glyphs = True
@@ -588,22 +587,6 @@ class Font:
 
                 with TemporaryLogLevel(logging.WARNING):
                     subsetter.subset(new)
-
-                if not hasattr(options, "prune_codepage_ranges"):
-                    from ufo2ft.util import calcCodePageRanges
-
-                    unicodes = set()
-                    for table in new["cmap"].tables:
-                        if table.isUnicode():
-                            unicodes.update(table.cmap.keys())
-                    bits = set(range(64)) - calcCodePageRanges(unicodes)
-                    if len(bits) == 64:
-                        bits -= {0}
-                    for bit in bits:
-                        if 0 <= bit < 32:
-                            new["OS/2"].ulCodePageRange1 &= ~(1 << bit)
-                        else:
-                            new["OS/2"].ulCodePageRange2 &= ~(1 << (bit - 32))
 
                 self.names = subset.get("names", {})
                 self.instances = subset.get("instances")

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cffsubr==0.2.9.post1
     # via
     #   -r requirements.in
     #   ufo2ft
-fonttools[ufo,woff]==4.47.2
+fonttools[ufo,woff]==4.51.0
     # via
     #   -r requirements.in
     #   axisregistry


### PR DESCRIPTION
We were instructing the subsetter to keep all name IDs, but we actually want to explicitly keep all defined names and let it prune unused name IDs, so we now do exactly that.

This requires a recent version of FontTools.