### PR TITLE
[Builder] Keep hinting when instancing CFF2 table

### DIFF
--- a/Builder/tirobuild.py
+++ b/Builder/tirobuild.py
@@ -647,7 +647,7 @@ class Font:
 
         logger.info(f"Removing overlaps from {self.filename}")
         try:
-            removeOverlaps(otf)
+            removeOverlaps(otf, removeHinting=False)
         except NotImplementedError:
             pass
         return otf


### PR DESCRIPTION
Previously FontTools didn’t support removing overlaps from CFF table, and we would use a fallback method, but recent versions started supporting CFF table and by default it removed hinting, but we want to keep font-level hinting data for the auto hinter.